### PR TITLE
Removed caching, since Azure variables may change

### DIFF
--- a/src/Serilog.Enrichers.AzureWebApps.NETStandard/EnvironmentVariableEnricher.cs
+++ b/src/Serilog.Enrichers.AzureWebApps.NETStandard/EnvironmentVariableEnricher.cs
@@ -6,15 +6,13 @@ namespace Serilog.Enrichers.AzureAppService.NETStandard
 {
     /// <summary>
     /// Generic log event enricher that takes the value of some environment variable and adds it as
-    /// a property with a specified name on Serilog events. The environment variable is expected to
-    /// remain constant during program execution and will therefore be cached.
+    /// a property with a specified name on Serilog events.
     /// </summary>
     public class EnvironmentVariableEnricher : ILogEventEnricher
     {
         private readonly string _serilogPropertyName;
         private readonly string _environmentVariableName;
         private readonly string _defaultValue;
-        private LogEventProperty _cachedProperty;
 
         /// <summary>
         /// Constructs a new enricher based on the given values.
@@ -34,14 +32,9 @@ namespace Serilog.Enrichers.AzureAppService.NETStandard
         /// </summary>
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            var cachedProp = _cachedProperty;
-            if (cachedProp == null)
-            {
-                string valueToUse = Environment.GetEnvironmentVariable(_environmentVariableName) ?? _defaultValue;
-                _cachedProperty = cachedProp = propertyFactory.CreateProperty(_serilogPropertyName, valueToUse);
-            }
-
-            logEvent.AddPropertyIfAbsent(cachedProp);
+            string value = Environment.GetEnvironmentVariable(_environmentVariableName) ?? _defaultValue;
+            var prop = propertyFactory.CreateProperty(_serilogPropertyName, value);
+            logEvent.AddPropertyIfAbsent(prop);
         }
     }
 }

--- a/src/Serilog.Enrichers.AzureWebApps/EnvironmentVariableEnricher.cs
+++ b/src/Serilog.Enrichers.AzureWebApps/EnvironmentVariableEnricher.cs
@@ -6,15 +6,13 @@ namespace Serilog.Enrichers.AzureAppService
 {
     /// <summary>
     /// Generic log event enricher that takes the value of some environment variable and adds it as
-    /// a property with a specified name on Serilog events. The environment variable is expected to
-    /// remain constant during program execution and will therefore be cached.
+    /// a property with a specified name on Serilog events.
     /// </summary>
     public class EnvironmentVariableEnricher : ILogEventEnricher
     {
         private readonly string _serilogPropertyName;
         private readonly string _environmentVariableName;
         private readonly string _defaultValue;
-        private LogEventProperty _cachedProperty;
 
         /// <summary>
         /// Constructs a new enricher based on the given values.
@@ -34,14 +32,9 @@ namespace Serilog.Enrichers.AzureAppService
         /// </summary>
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-            var cachedProp = _cachedProperty;
-            if (cachedProp == null)
-            {
-                string valueToUse = Environment.GetEnvironmentVariable(_environmentVariableName) ?? _defaultValue;
-                _cachedProperty = cachedProp = propertyFactory.CreateProperty(_serilogPropertyName, valueToUse);
-            }
-
-            logEvent.AddPropertyIfAbsent(cachedProp);
+            string value = Environment.GetEnvironmentVariable(_environmentVariableName) ?? _defaultValue;
+            var prop = propertyFactory.CreateProperty(_serilogPropertyName, value);
+            logEvent.AddPropertyIfAbsent(prop);
         }
     }
 }


### PR DESCRIPTION
 - fix: turns out it is not safe to cache Azure environment variables
   after all; after a slot swap between staging and production, the host
   was incorrectly reported as staging host; this is probably because the
   program is restarted _before_ the swap, not after; attempt to solve by
   removing caching